### PR TITLE
Fix three broken links across all nine skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Sign up for free at [publora.com/register](https://publora.com/register)
 
 ### Step 3: Connect Your Social Accounts
 
-1. Go to [Publora Dashboard](https://publora.com/dashboard)
+1. Go to [Publora Dashboard](https://app.publora.com/dashboard)
 2. Click "Connect Account" for each platform
 3. Complete OAuth authorization (or bot setup for Telegram)
 
 ### Step 4: Get Your API Key
 
-1. Go to [publora.com/settings/api](https://publora.com/settings/api)
+1. Go to [publora.com/settings/api](https://app.publora.com/dashboard/api)
 2. Click "Create API Key"
 3. Copy the key (you'll need it for MCP config)
 
@@ -151,7 +151,7 @@ Yes. Upgrade or downgrade from Settings. Changes take effect immediately.
 - [Pricing](https://publora.com/pricing)
 - [Documentation](https://docs.publora.com)
 - [MCP Tools Reference](https://docs.publora.com/mcp/tools-reference)
-- [API Documentation](https://docs.publora.com/api)
+- [API Documentation](https://docs.publora.com)
 
 ## License
 

--- a/skills/bluesky-post/SKILL.md
+++ b/skills/bluesky-post/SKILL.md
@@ -15,8 +15,8 @@ Create and schedule posts to Bluesky using the Publora MCP server. Supports text
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Generate app password** in Bluesky Settings > App Passwords (NOT your main password)
-3. **Connect Bluesky** in [Publora Dashboard](https://publora.com/dashboard) using your handle + app password
-4. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+3. **Connect Bluesky** in [Publora Dashboard](https://app.publora.com/dashboard) using your handle + app password
+4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/instagram-post/SKILL.md
+++ b/skills/instagram-post/SKILL.md
@@ -15,8 +15,8 @@ Create and schedule Instagram posts using the Publora MCP server. Supports image
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Convert to Business account** in Instagram settings (Personal and Creator accounts are NOT supported by the API)
-3. **Connect Instagram** via OAuth in [Publora Dashboard](https://publora.com/dashboard)
-4. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+3. **Connect Instagram** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/linkedin-analytics/SKILL.md
+++ b/skills/linkedin-analytics/SKILL.md
@@ -14,8 +14,8 @@ Get detailed analytics for your LinkedIn posts and profile using the Publora MCP
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
-2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/linkedin-post/SKILL.md
+++ b/skills/linkedin-post/SKILL.md
@@ -14,8 +14,8 @@ Create and schedule LinkedIn posts using the Publora MCP server. Supports text p
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
-2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/social-post/SKILL.md
+++ b/skills/social-post/SKILL.md
@@ -14,11 +14,11 @@ Create and schedule posts to YouTube, Facebook Pages, and Mastodon using the Pub
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
-2. **Connect platforms** via OAuth in [Publora Dashboard](https://publora.com/dashboard):
+2. **Connect platforms** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard):
    - **YouTube**: Google OAuth (requires YouTube channel)
    - **Facebook**: Facebook OAuth (Pages only, not personal profiles)
    - **Mastodon**: OAuth (mastodon.social instance)
-3. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/telegram-post/SKILL.md
+++ b/skills/telegram-post/SKILL.md
@@ -21,8 +21,8 @@ Create and schedule posts to Telegram channels and groups using the Publora MCP 
 4. **Add bot to your channel:**
    - Add the bot as **administrator** to your channel/group
    - Grant `can_post_messages` permission
-5. **Connect in Publora** at [Dashboard](https://publora.com/dashboard) with bot token and channel name
-6. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+5. **Connect in Publora** at [Dashboard](https://app.publora.com/dashboard) with bot token and channel name
+6. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 7. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/threads-post/SKILL.md
+++ b/skills/threads-post/SKILL.md
@@ -14,8 +14,8 @@ Create and schedule posts on Meta's Threads using the Publora MCP server. Suppor
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
-2. **Connect Threads** via Instagram OAuth in [Publora Dashboard](https://publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+2. **Connect Threads** via Instagram OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/tiktok-post/SKILL.md
+++ b/skills/tiktok-post/SKILL.md
@@ -14,8 +14,8 @@ Upload and schedule videos to TikTok using the Publora MCP server. Supports priv
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
-2. **Connect TikTok** via OAuth in [Publora Dashboard](https://publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+2. **Connect TikTok** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json

--- a/skills/x-post/SKILL.md
+++ b/skills/x-post/SKILL.md
@@ -17,8 +17,8 @@ Create and schedule posts to X (Twitter) using the Publora MCP server. Supports 
 
 1. **Create account** at [publora.com/register](https://publora.com/register)
 2. **Choose Pro or Premium plan** (X/Twitter requires paid plan)
-3. **Connect X/Twitter** via OAuth in [Publora Dashboard](https://publora.com/dashboard)
-4. **Get API key** at [publora.com/settings/api](https://publora.com/settings/api)
+3. **Connect X/Twitter** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
+4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
 5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json


### PR DESCRIPTION
Every skill pointed users at pages that return 404. Checked each link in the repository against production; three were dead.

| Was | Now | Where |
|---|---|---|
| `https://publora.com/settings/api` | `https://app.publora.com/dashboard/api` | all nine skills, in the "get your API key" step |
| `https://publora.com/dashboard` | `https://app.publora.com/dashboard` | wherever the reader is told to connect an account |
| `https://docs.publora.com/api` | `https://docs.publora.com` | README |

The first one hurts most: it is the step where a new user goes to fetch the key, and it has been sending them to a 404 since the skills were published.

The remaining links were verified and left alone: `docs.publora.com`, `docs.publora.com/mcp/tools-reference`, `publora.com`, `publora.com/pricing`, `publora.com/register` and `t.me/BotFather` all answer 200. The `api.publora.com` endpoints answer 401 or 404 to a bare GET, which is expected for POST-only routes behind auth.

Found while preparing the Kilo Marketplace submission, which links `linkedin-post` straight from this repository.