### PR TITLE
Fix the facts the skills get wrong (pricing, phantom MCP tools, config path, limits)

### DIFF
--- a/skills/bluesky-post/SKILL.md
+++ b/skills/bluesky-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bluesky-post
-description: Post to Bluesky with rich text facets, images, videos, and alt text support via Publora MCP
+description: Use when the user wants to post or schedule to Bluesky through Publora. Handles the 300-character cap, auto-detected hashtags and links, up to 4 images with alt text, and videos. Needs a Bluesky app password, never the main password. Not for Mastodon (use social-post).
 ---
 
 # Bluesky Post
@@ -9,29 +9,22 @@ Create and schedule posts to Bluesky using the Publora MCP server. Supports text
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Generate app password** in Bluesky Settings > App Passwords (NOT your main password)
 3. **Connect Bluesky** in [Publora Dashboard](https://app.publora.com/dashboard) using your handle + app password
-4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+4. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+5. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -63,21 +56,13 @@ Example IDs: `bluesky-did:plc:abc123xyz`, `bluesky-did:plc:def456uvw`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
 
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
-
 ## Platform Limits
 
 | Feature | Limit |
 |---------|-------|
 | Characters | 300 |
 | Images | Up to 4 per post |
-| Image size | ~1 MB (976.56 KB) |
+| Image size | exactly 2,000,000 bytes (decimal, not 2 MiB) |
 | Video duration | 3 minutes |
 | Video size | 50-100 MB (based on duration) |
 | Videos per day | 25 |
@@ -108,7 +93,8 @@ Create a new Bluesky post.
 **Parameters:**
 - `platforms`: Array with your Bluesky connection ID (e.g., `["bluesky-did:plc:abc123xyz"]`)
 - `content`: Post text (up to 300 characters)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 - `altTexts`: Array of alt text for images (optional)
 
 ### get_upload_url
@@ -120,8 +106,17 @@ Get presigned URL for media uploads.
 - `contentType`: `image/jpeg`, `image/png`, `video/mp4`
 - `type`: `"image"` or `"video"`
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Examples
 
@@ -165,7 +160,7 @@ Schedule this for tomorrow at 10 AM:
 
 2. **All images converted to JPEG**: Regardless of input format (PNG, WebP, GIF), all images are converted to JPEG before upload.
 
-3. **~1 MB image limit**: The AT Protocol enforces a strict ~1 MB limit. Compress images to 80-85% JPEG quality.
+3. **Hard 2,000,000-byte image limit**: the AT Protocol enforces an exact decimal byte ceiling, not a rounded 2 MiB. Compress to 80-85% JPEG quality and check the byte count.
 
 4. **DID-based platform ID**: Unlike other platforms using numeric IDs, Bluesky uses `did:plc:xxx` format.
 
@@ -196,7 +191,7 @@ Schedule this for tomorrow at 10 AM:
 | Error | Cause | Solution |
 |-------|-------|----------|
 | "Invalid credentials" | Wrong password type | Use app password, not main password |
-| "Image too large" | Over ~1 MB | Compress to 80-85% JPEG quality |
+| "Image too large" | Over 2,000,000 bytes | Compress to 80-85% JPEG quality |
 | "Content too long" | Over 300 chars | Shorten content (no auto-threading) |
 | "Video daily limit" | 25 videos reached | Wait 24 hours |
 | "Email not verified" | Trying to upload video | Verify email in Bluesky settings |

--- a/skills/instagram-post/SKILL.md
+++ b/skills/instagram-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: instagram-post
-description: Post to Instagram with images, carousels, Reels, and Stories via Publora MCP (Business account required)
+description: Use when the user wants to post or schedule to Instagram through Publora: a single image, a 2-10 image carousel, a Reel or a Story. Requires a Business account and JPEG images; PNG and text-only posts are rejected by the API. Not for Threads (use threads-post).
 ---
 
 # Instagram Post
@@ -9,29 +9,22 @@ Create and schedule Instagram posts using the Publora MCP server. Supports image
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Convert to Business account** in Instagram settings (Personal and Creator accounts are NOT supported by the API)
 3. **Connect Instagram** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+4. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+5. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -62,14 +55,6 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 Example IDs: `instagram-11223344`, `instagram-55667788`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
-
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
 
 ## Platform Limits (API vs Native App)
 
@@ -113,7 +98,8 @@ Create a new Instagram post.
 **Parameters:**
 - `platforms`: Array with your Instagram connection ID (e.g., `["instagram-11223344"]`)
 - `content`: Caption text (up to 2,200 characters)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get presigned URL for media uploads.
@@ -124,8 +110,17 @@ Get presigned URL for media uploads.
 - `contentType`: Must be `image/jpeg` for images, `video/mp4` for video
 - `type`: `"image"` or `"video"`
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Video Type Settings (via REST API)
 

--- a/skills/linkedin-analytics/SKILL.md
+++ b/skills/linkedin-analytics/SKILL.md
@@ -1,36 +1,29 @@
 ---
 name: linkedin-analytics
-description: Analyze LinkedIn performance, track engagement metrics, and manage reactions/comments via Publora MCP
+description: Analyze LinkedIn performance and manage engagement through Publora. Use when the user asks how a LinkedIn post or account performed (impressions, reach, reactions, comments, reshares, follower growth) or wants to react, comment, reshare or resolve an @mention. Statistics run over the REST API, engagement over MCP tools. Not for creating posts (use linkedin-post).
 ---
 
 # LinkedIn Analytics
 
-Get detailed analytics for your LinkedIn posts and profile using the Publora MCP server. Track impressions, engagement, follower growth, and interact with posts through reactions and comments.
+Track impressions, engagement and follower growth for your LinkedIn posts and profile, and interact with posts through reactions, comments and reshares. Statistics come from the REST API; reactions, comments, reshares and mention lookups are MCP tools.
 
 ## Prerequisites
 
-**Plans:** Starter (free), Pro, Premium - LinkedIn is available on all plans including free.
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+3. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+4. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -71,46 +64,41 @@ Example IDs: `linkedin-Tz9W5i6ZYG`, `linkedin-abc123xyz`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
 
-## Analytics Tools
+## Analytics Tools (REST only)
 
-### linkedin_post_stats
-Get engagement metrics for a specific LinkedIn post.
+LinkedIn analytics are **not exposed as MCP tools**. The MCP server carries posting, media and LinkedIn engagement tools; statistics live only on the REST API, so call these endpoints directly with the `x-publora-key` header. Asking an agent for an `linkedin_post_stats` MCP tool will fail: there is no such tool.
 
-**Parameters:**
-- `postedId`: LinkedIn post URN (e.g., `urn:li:share:123456` or `urn:li:ugcPost:123456`)
-- `platformId`: Platform connection ID (e.g., `linkedin-abc123`)
-- `queryTypes` (optional): Metrics to fetch: `IMPRESSION`, `MEMBERS_REACHED`, `RESHARE`, `REACTION`, `COMMENT`
+### POST /linkedin-post-statistics
+Engagement metrics for one post.
 
-**Response includes:**
-- Impressions (total views)
-- Unique impressions (members reached)
-- Reactions count
-- Comments count
-- Shares/reposts
-- Engagement rate
+**Body:**
+- `platformId`: platform connection ID (e.g. `linkedin-abc123`), from `list_connections`
+- `postedId`: post URN (`urn:li:share:...` or `urn:li:ugcPost:...`)
+- `queryTypes` (optional): `IMPRESSION`, `MEMBERS_REACHED`, `RESHARE`, `REACTION`, `COMMENT`, or `ALL`
 
-### linkedin_account_stats
-Get aggregated statistics for your LinkedIn account.
+**Returns:** impressions, unique impressions (members reached), reactions, comments, reshares, and a `cached` flag telling you whether the numbers came from cache.
 
-**Parameters:**
-- `platformId`: Platform connection ID
-- `queryTypes` (optional): Metrics to fetch
-- `aggregation` (optional): `DAILY` or `TOTAL` (default: TOTAL)
+### POST /linkedin-account-statistics
+Aggregated statistics for the account.
 
-### linkedin_followers
-Get follower count or growth over time.
+**Body:** `platformId`, optional `queryTypes`, optional `aggregation` (`DAILY` or `TOTAL`, default `TOTAL`).
 
-**Parameters:**
-- `platformId`: Platform connection ID
-- `period` (optional): `lifetime` or `daily`
-- `dateRange` (optional): For daily period: `{start: {year, month, day}, end: {year, month, day}}`
+### POST /linkedin-followers
+Follower count or growth over time.
 
-### linkedin_profile_summary
-Get a combined profile overview with followers and stats.
+**Body:** `platformId`, optional `period` (`lifetime` or `daily`), optional `dateRange` (`{start: {year, month, day}, end: {year, month, day}}`).
 
-**Parameters:**
-- `platformId`: Platform connection ID
-- `dateRange` (optional): Date range for stats
+### POST /linkedin-profile-summary
+Combined profile overview: followers plus statistics.
+
+**Body:** `platformId`, optional `dateRange`.
+
+```bash
+curl -X POST "https://api.publora.com/api/v1/linkedin-post-statistics" \
+  -H "x-publora-key: sk_your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{"platformId": "linkedin-abc123", "postedId": "urn:li:share:7123456789012345678", "queryTypes": "ALL"}'
+```
 
 ## Engagement Tools
 
@@ -146,6 +134,23 @@ Post a comment on a LinkedIn post (max 1,250 characters).
 - `platformId`: Platform connection ID
 - `message`: Comment text (max 1,250 characters)
 - `parentComment` (optional): Comment URN for nested replies
+
+### linkedin_create_reshare
+Reshare an existing post, with optional commentary.
+
+**Parameters:**
+- `postedId`: the original post's **share URN** (`urn:li:share:...` or `urn:li:ugcPost:...`)
+- `platformId`: platform connection ID
+- `commentary` (optional): your text above the reshare
+
+Note: a LinkedIn feed URL carries an `activity` id, which is not always the same as the share id. Use the `postedId` returned by `get_post`, not a hand-converted activity id.
+
+### linkedin_list_mentionables
+Resolve names to the URNs that @mentions need, so you never hand-write a member id.
+
+**Parameters:**
+- `platformId`: platform connection ID
+- `query`: the name to search for
 
 ### linkedin_delete_comment
 Remove a comment you made.

--- a/skills/linkedin-analytics/SKILL.md
+++ b/skills/linkedin-analytics/SKILL.md
@@ -135,6 +135,14 @@ Post a comment on a LinkedIn post (max 1,250 characters).
 - `message`: Comment text (max 1,250 characters)
 - `parentComment` (optional): Comment URN for nested replies
 
+### linkedin_delete_comment
+Remove a comment you made.
+
+**Parameters:**
+- `postedId`: LinkedIn post URN
+- `commentId`: Comment URN or numeric ID
+- `platformId`: Platform connection ID
+
 ### linkedin_create_reshare
 Reshare an existing post, with optional commentary.
 
@@ -151,14 +159,6 @@ Resolve names to the URNs that @mentions need, so you never hand-write a member 
 **Parameters:**
 - `platformId`: platform connection ID
 - `query`: the name to search for
-
-### linkedin_delete_comment
-Remove a comment you made.
-
-**Parameters:**
-- `postedId`: LinkedIn post URN
-- `commentId`: Comment URN or numeric ID
-- `platformId`: Platform connection ID
 
 ## Example Prompts
 

--- a/skills/linkedin-post/SKILL.md
+++ b/skills/linkedin-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-post
-description: Create and schedule LinkedIn posts with text, images, videos, and documents via Publora MCP
+description: Use when the user wants to publish or schedule a LinkedIn post through Publora: text, a multi-image grid, a video, a PDF document, or @mentions. Not for analytics, reactions, comments or reshares (use linkedin-analytics), and not for other platforms.
 ---
 
 # LinkedIn Post
@@ -9,28 +9,21 @@ Create and schedule LinkedIn posts using the Publora MCP server. Supports text p
 
 ## Prerequisites
 
-**Plans:** Starter (free), Pro, Premium - LinkedIn is available on all plans including free.
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Connect LinkedIn** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+3. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+4. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -62,14 +55,6 @@ Example IDs: `linkedin-Tz9W5i6ZYG`, `linkedin-abc123xyz`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
 
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
-
 ## Platform Limits
 
 | Feature | Limit |
@@ -91,7 +76,8 @@ Create a new LinkedIn post or schedule for later.
 **Parameters:**
 - `platforms`: Array including your LinkedIn connection ID (e.g., `["linkedin-abc123"]`)
 - `content`: Post text (up to 3,000 characters)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get a presigned URL to upload media.
@@ -102,8 +88,17 @@ Get a presigned URL to upload media.
 - `contentType`: MIME type (e.g., "image/jpeg", "video/mp4", "application/pdf")
 - `type`: "image" or "video"
 
-### list_posts / update_post / delete_post
-Manage your scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Mentioning People and Companies
 
@@ -120,6 +115,8 @@ Great insights from @{urn:li:person:4986615|Serge Bulaev} at @{urn:li:organizati
 ```
 
 **Important:** The display name must exactly match the LinkedIn profile name (case-sensitive), including company suffixes like "Inc", "LLC", etc.
+
+**Do not hand-write member ids.** The `linkedin_list_mentionables` MCP tool resolves a name to the correct URN; see the `linkedin-analytics` skill.
 
 ## Important API Restrictions
 

--- a/skills/social-post/SKILL.md
+++ b/skills/social-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: social-post
-description: Post to YouTube, Facebook Pages, and Mastodon via Publora MCP - unified skill for video and fediverse platforms
+description: Use when the user wants to post or schedule to YouTube, a Facebook Page or Mastodon through Publora. YouTube needs a video on every post, Facebook publishes to Pages only, Mastodon caps at 500 characters. Not for the platforms that have their own skill.
 ---
 
 # Social Post (YouTube, Facebook, Mastodon)
@@ -9,7 +9,7 @@ Create and schedule posts to YouTube, Facebook Pages, and Mastodon using the Pub
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
@@ -18,22 +18,15 @@ Create and schedule posts to YouTube, Facebook Pages, and Mastodon using the Pub
    - **YouTube**: Google OAuth (requires YouTube channel)
    - **Facebook**: Facebook OAuth (Pages only, not personal profiles)
    - **Mastodon**: OAuth (mastodon.social instance)
-3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+3. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+4. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -65,14 +58,6 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 - Mastodon: `mastodon-{id}` (e.g., `mastodon-456`)
 
 📖 **Docs:** [docs.publora.com](https://docs.publora.com)
-
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
 
 ---
 
@@ -223,7 +208,8 @@ Create a new post on any platform.
 **Parameters:**
 - `platforms`: Array of platform IDs (e.g., `["youtube-UCxxx", "facebook-123", "mastodon-456"]`)
 - `content`: Post text
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get presigned URL for media uploads.
@@ -234,8 +220,17 @@ Get presigned URL for media uploads.
 - `contentType`: MIME type
 - `type`: `"image"` or `"video"`
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ---
 

--- a/skills/telegram-post/SKILL.md
+++ b/skills/telegram-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram-post
-description: Post to Telegram channels and groups with markdown formatting, media support, and message options via Publora MCP
+description: Use when the user wants to post or schedule to a Telegram channel or group through Publora, using a bot. Covers Telegram markdown, silent delivery, link previews and forward protection. Bot API caps media captions at 1,024 characters and videos at 50 MB.
 ---
 
 # Telegram Post
@@ -9,7 +9,7 @@ Create and schedule posts to Telegram channels and groups using the Publora MCP 
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
@@ -22,22 +22,15 @@ Create and schedule posts to Telegram channels and groups using the Publora MCP 
    - Add the bot as **administrator** to your channel/group
    - Grant `can_post_messages` permission
 5. **Connect in Publora** at [Dashboard](https://app.publora.com/dashboard) with bot token and channel name
-6. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-7. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+6. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+7. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -68,14 +61,6 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 Example IDs: `telegram-1001234567890`, `telegram--1002345678901`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
-
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
 
 ## Platform Limits (Bot API)
 
@@ -114,13 +99,23 @@ Create a new Telegram post.
 **Parameters:**
 - `platforms`: Array with your Telegram connection ID (e.g., `["telegram-1001234567890"]`)
 - `content`: Message text (supports markdown)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get presigned URL for media uploads.
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Post Options (via REST API)
 

--- a/skills/threads-post/SKILL.md
+++ b/skills/threads-post/SKILL.md
@@ -1,36 +1,29 @@
 ---
 name: threads-post
-description: Create and schedule Threads posts with auto-threading, image carousels, and reply control via Publora MCP
+description: Create and schedule Threads posts with image carousels and reply control via Publora MCP. Use when the user wants to post to Meta's Threads. Multi-part threading is currently disabled by the platform, so long content stays a single post. Not for Instagram (use instagram-post) or X threads (use x-post).
 ---
 
 # Threads Post
 
-Create and schedule posts on Meta's Threads using the Publora MCP server. Supports auto-threading for long content, image carousels (2-10 images), and reply control settings.
+Create and schedule posts on Meta's Threads using the Publora MCP server. Supports single posts, image carousels (2-20 images) and reply control. Multi-part threading is disabled by the platform connection right now.
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Connect Threads** via Instagram OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+3. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+4. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -60,14 +53,6 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 
 📖 **Docs:** [docs.publora.com](https://docs.publora.com)
 
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
-
 ## Platform Limits
 
 | Feature | Limit |
@@ -75,11 +60,11 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 | Characters per post | 500 |
 | Hashtags | 1 per post maximum |
 | Links | 5 per post maximum |
-| Images per carousel | 2-10 |
+| Images per carousel | 2-20 |
 | Image size | 8 MB |
 | Image formats | JPEG, PNG (WebP auto-converted) |
 | Video duration | 5 minutes |
-| Video size | 500 MB |
+| Video size | 1 GB |
 | Video formats | MP4, MOV |
 | Posts per day | 250 |
 | Replies per day | 1,000 |
@@ -92,39 +77,33 @@ Create a new Threads post or thread.
 **Parameters:**
 - `platforms`: Array with your Threads connection ID (e.g., `["threads-12345"]`)
 - `content`: Post text (auto-threads if over 500 chars)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get a presigned URL to upload images.
 
-### list_posts / update_post / delete_post
-Manage your scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
 
-## Auto-Threading
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
 
-When content exceeds 500 characters, Publora automatically creates a connected thread:
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
 
-1. **Smart splitting**: Content is split at paragraph breaks (`\n\n`), then sentence boundaries (`. `, `! `, `? `), then word boundaries
-2. **Auto-numbering**: Each part gets `(1/N)`, `(2/N)`, etc. at the end
-3. **Reply chain**: Posts are connected using Threads' `reply_to_id` parameter
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
-### Manual Thread Breaks
+## Long Content
 
-Use `---` on its own line to force a thread break:
+Threads posts are capped at 500 characters and **Publora's multi-part threading is currently disabled** while the Threads app connection is being restored. Content over the limit is not split automatically, so:
 
-```
-This is my first post in the thread.
+- Keep the post inside 500 characters, or
+- Publish the parts yourself as separate posts, or
+- Move the long-form version to a platform that threads today (X) and link to it.
 
----
-
-This is my second post in the thread.
-
----
-
-And this is my third post!
-```
-
-Or use explicit markers `[1/3]`, `[2/3]`, `[3/3]` (square brackets are preserved as written).
+Manual `---` separators and `[1/3]` markers are preserved as written but do **not** create a connected reply chain right now. Contact support@publora.com for the restore timeline.
 
 ## Reply Control
 
@@ -162,11 +141,14 @@ Post this to Threads:
 Create a Threads carousel with these 5 product evolution screenshots.
 Caption: "From concept to launch - our 6-month journey. #buildinpublic"
 ```
-Note: Requires 2-10 images. Videos in carousels are not supported.
+Note: Requires 2-20 images. Videos in carousels are not supported.
 
-### Long-Form Thread
+### Long Content (published as separate posts)
+
+Threading is disabled, so ask for the parts explicitly:
+
 ```
-Create a Threads thread from this content:
+Post this to Threads as separate posts:
 "Thread: 7 mistakes I made as a first-time founder
 
 ---
@@ -209,5 +191,5 @@ Schedule this for tomorrow at 10 AM:
 | "Account not connected" | Threads/Instagram OAuth expired | Reconnect via Publora dashboard |
 | "Content too long" | Post exceeds 500 chars and threading failed | Manually add `---` breaks |
 | "Media upload failed" | Wrong format or size | Check: images < 8 MB, JPEG/PNG only |
-| "Carousel requires 2-10 items" | Wrong number of images | Ensure 2-10 images for carousel |
+| "Carousel requires 2-20 items" | Wrong number of images | Ensure 2-20 images for carousel |
 | 250 posts/day exceeded | Rate limit reached | Wait 24 hours |

--- a/skills/tiktok-post/SKILL.md
+++ b/skills/tiktok-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiktok-post
-description: Upload videos to TikTok with privacy controls and interaction settings via Publora MCP
+description: Use when the user wants to upload or schedule a TikTok video through Publora, with privacy, comment, duet, stitch and commercial-disclosure settings. Video only, 3 seconds to 10 minutes, 23+ FPS. Unaudited apps can publish private videos only. Not for Reels (use instagram-post).
 ---
 
 # TikTok Post
@@ -9,28 +9,21 @@ Upload and schedule videos to TikTok using the Publora MCP server. Supports priv
 
 ## Prerequisites
 
-**Plans:** Free Starter (15 posts/month), Pro, Premium
+**Plans:** Works on the free Starter plan. Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 ### Getting Started
 
 1. **Create account** at [publora.com/register](https://publora.com/register) (free)
 2. **Connect TikTok** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-3. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-4. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+3. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+4. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -68,14 +61,6 @@ Example IDs: `tiktok-99887766`, `tiktok-123456789`
 
 📖 **Full API documentation:** [docs.publora.com](https://docs.publora.com)
 
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | 15 | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
-
 ## Platform Limits (API vs Native App)
 
 **Critical API limits that differ from native TikTok app:**
@@ -112,7 +97,8 @@ Create a new TikTok post.
 **Parameters:**
 - `platforms`: Array with your TikTok connection ID (e.g., `["tiktok-99887766"]`)
 - `content`: Video caption (up to 2,200 characters)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get presigned URL for video upload.
@@ -123,8 +109,17 @@ Get presigned URL for video upload.
 - `contentType`: `video/mp4`, `video/quicktime`, or `video/webm`
 - `type`: `"video"`
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Platform Settings (via REST API)
 

--- a/skills/x-post/SKILL.md
+++ b/skills/x-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-post
-description: Post to X (Twitter) with auto-threading, images, and videos via Publora MCP
+description: Use when the user wants to post or schedule to X (Twitter) through Publora, including threads auto-split past 280 characters, up to 4 images, or a video up to 140 seconds. X needs a paid Publora plan. Not for Threads or Bluesky (each has its own skill).
 ---
 
 # X/Twitter Post
@@ -9,7 +9,7 @@ Create and schedule posts to X (Twitter) using the Publora MCP server. Supports 
 
 ## Prerequisites
 
-**Plans:** Pro ($2.99/account/month), Premium ($9.99/account/month)
+**Plans:** Requires a paid plan (X API costs are passed through). Current limits and pricing: [publora.com/pricing](https://publora.com/pricing).
 
 **Important:** X/Twitter is NOT available on the free Starter plan due to Twitter API costs.
 
@@ -18,22 +18,15 @@ Create and schedule posts to X (Twitter) using the Publora MCP server. Supports 
 1. **Create account** at [publora.com/register](https://publora.com/register)
 2. **Choose Pro or Premium plan** (X/Twitter requires paid plan)
 3. **Connect X/Twitter** via OAuth in [Publora Dashboard](https://app.publora.com/dashboard)
-4. **Get API key** at [publora.com/settings/api](https://app.publora.com/dashboard/api)
-5. **Configure MCP** in Claude Desktop (`~/.claude/claude_desktop_config.json`):
+4. **Get API key** at [app.publora.com/dashboard/api](https://app.publora.com/dashboard/api)
+5. **Connect your agent** to the MCP server at `https://mcp.publora.com`, authenticating with `Authorization: Bearer sk_YOUR_API_KEY`. In Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "publora": {
-      "type": "http",
-      "url": "https://mcp.publora.com",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_KEY"
-      }
-    }
-  }
-}
+```bash
+claude mcp add publora --transport http https://mcp.publora.com \
+  --header "Authorization: Bearer sk_YOUR_API_KEY"
 ```
+
+   Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai connector each need a different config file or flow: see [client setup](https://docs.publora.com/mcp/client-setup) for the exact path and snippet.
 
 ### REST API Fallback
 
@@ -63,21 +56,13 @@ curl -X POST "https://api.publora.com/api/v1/create-post" \
 
 📖 **Docs:** [docs.publora.com](https://docs.publora.com)
 
-### Plan Limits
-
-| Plan | Posts/month | Price |
-|------|-------------|-------|
-| Starter | **Not available** | Free |
-| Pro | 100/account | $2.99/account/month |
-| Premium | 500/account | $9.99/account/month |
-
 ## Platform Limits
 
 | Feature | API Limit | Notes |
 |---------|-----------|-------|
 | Characters | 280 | Emojis count as 2 characters |
 | Images | Up to 4 | Auto-converted to PNG (max 1000px width) |
-| Video duration | **2 minutes** | API limit (native app allows 2:20) |
+| Video duration | **2 min 20 s (140 s)** | Publora validates X videos at 140 s |
 | Video size | 512 MB | MP4, MOV formats |
 | Threading | Automatic | Content over 280 chars split with `(1/N)` markers |
 
@@ -122,7 +107,8 @@ Create a new X/Twitter post or thread.
 **Parameters:**
 - `platforms`: Array with your X connection ID (e.g., `["twitter-12345678"]`)
 - `content`: Post text (auto-threads if over 280 chars)
-- `scheduledTime`: ISO 8601 datetime (**required** - for immediate posting, use current time + 1 minute)
+- `scheduledTime`: ISO 8601 UTC datetime. **Optional**: omit it and the post is created as a draft. Send a future time to schedule. A time five or more minutes in the past is rejected with `SCHEDULED_TIME_IN_PAST`, so for immediate posting use the current time plus a minute.
+- `mediaUrls`: up to 10 public **https** image or video URLs. Publora downloads them server-side and attaches them *before* validation, so media and scheduling happen in one call. This is the one-shot alternative to the draft then `get_upload_url` then `complete_media` flow. Ingestion is rate-limited to 60 URLs per hour.
 
 ### get_upload_url
 Get presigned URL for media uploads.
@@ -133,8 +119,17 @@ Get presigned URL for media uploads.
 - `contentType`: `image/png`, `image/jpeg`, `video/mp4`
 - `type`: `"image"` or `"video"`
 
-### list_posts / update_post / delete_post
-Manage scheduled and draft posts.
+### complete_media
+Finalize a file uploaded through `get_upload_url`, after the presigned `PUT` succeeds. Optional, because scheduling also finalizes pending media, but calling it early surfaces format and probe errors before publish. Not needed for media attached with `mediaUrls`.
+
+**Parameters:**
+- `mediaId`: the id returned by `get_upload_url`
+
+### list_connections
+List your connected accounts with their platform IDs. Call this first and copy the IDs verbatim; they are never guessable.
+
+### list_posts / get_post / update_post / delete_post
+Manage scheduled and draft posts. `update_post` also patches `content` and `platforms` on a draft or scheduled post, so fixing a typo or retargeting no longer means delete and recreate. `delete_media` and `prune_media_reference` clean up uploaded files.
 
 ## Examples
 
@@ -179,7 +174,7 @@ Schedule this for tomorrow at 9 AM:
 
 1. **Pro plan required**: X/Twitter is excluded from the free Starter plan due to Twitter API costs.
 
-2. **2-minute video limit**: The X API limits videos to 2 minutes, even though the native app allows longer videos.
+2. **140-second video limit**: Publora validates X videos at 2 minutes 20 seconds (140 seconds). Longer videos fail validation.
 
 3. **Image auto-conversion**: All images are converted to PNG (max 1000px width) before upload. Animated GIFs lose animation.
 
@@ -210,6 +205,6 @@ Schedule this for tomorrow at 9 AM:
 |-------|-------|----------|
 | "X/Twitter requires Pro plan" | Using Starter plan | Upgrade to Pro at publora.com/settings |
 | "Content too long" | Over 280 chars and threading failed | Add manual `---` breaks |
-| "Video too long" | Over 2 minutes | Trim video to under 2 minutes |
+| "Video too long" | Over 140 seconds | Trim video to under 2 min 20 s |
 | "Too many images" | More than 4 images | Reduce to 4 or fewer |
 | "Rate limit exceeded" | X API limit reached | Wait and retry |


### PR DESCRIPTION
The skills have had no content update since 25 March while the product moved on. The repo takes roughly **15 installs a day** (1.7K on skills.sh, 559 clones per 14 days), so every one of those users currently reads a price that does not exist and can be told to call MCP tools that are not there.

Nothing here is a style change. Each item below is a fact that is wrong today, verified against the live API, `publora/publora-api-docs`, and `publora.com/pricing.md`.

## Wrong facts

**Pricing, in 10 places.** Skills quote Pro $2.99 and Premium $9.99 with 100 and 500 posts per month. Live: Starter free (15 posts, 3 accounts), Pro graduated per account at $5.99 / $2.99 / $0.99 with **unlimited posts**, Agency custom, and **no Premium plan exists**. Rather than update the numbers, every price digit is removed and each skill links `publora.com/pricing`. The machine-readable `pricing.md` is the source of truth, so this cannot drift again.

**Four MCP tools that do not exist.** `linkedin-analytics` documents `linkedin_post_stats`, `linkedin_account_stats`, `linkedin_followers` and `linkedin_profile_summary`. None are in the live `tools/list` (16 tools) or in `docs/mcp/tools-reference.md`. An agent following the skill calls a tool that is not there. Analytics is now documented as REST-only with the real endpoint bodies, and the two real tools nobody had documented, `linkedin_create_reshare` and `linkedin_list_mentionables`, are added.

**Claude Desktop config path.** All nine skills said `~/.claude/claude_desktop_config.json`. That is not where Claude Desktop keeps its config. Replaced with the Claude Code command plus a link to `docs/mcp/client-setup`, which already documents Claude Desktop, Cursor, Codex, OpenClaw and the claude.ai OAuth connector.

**`scheduledTime` is optional, not required.** Omitting it creates a draft. The future-time advice stays, since past times are rejected.

**Threads contradicted itself.** A full auto-threading section, then a restriction saying multi-part threads are disabled. They are disabled, so the section now says what an agent should do with long content instead.

**Limit drift** against `docs/guides/platform-limits.md`:

| Skill said | Reality |
|---|---|
| X video 2:00 | 2:20 (140 s), which is what Publora validates |
| Bluesky image ~1 MB | exactly 2,000,000 bytes, decimal |
| Threads video 500 MB | 1 GB |
| Threads carousel 2-10 | 2-20 images |

## Capabilities the product has and the skills hid

- **`mediaUrls`**: up to 10 public https URLs on `create-post`, downloaded server-side and attached *before* validation, so media and scheduling take one call instead of a four-step upload dance. It was in no skill.
- **`complete_media`** and **`list_connections`** were missing from every tool list. The documented upload flow was incomplete without the first, and platform IDs are not guessable without the second.
- **`update_post`** can patch `content` and `platforms` since July, so fixing a typo no longer means delete and recreate.

## Descriptions

All nine rewritten as triggers: 150-300 chars, starting with when to fire, naming the platform and Publora, ending with a "Not for X (use Y)" sentinel. They were 75-113 chars of prose. This is the exact field skills.sh and the agents match on.

## Verification

- every `https://` link checked; the only non-200s are POST endpoints answering GET, `mcp.publora.com` asking for auth, and the `example.com` placeholders
- frontmatter linted: `name` matches folder, description length in range, no em dashes
- `grep -E '\$[0-9]'` over `skills/` is empty
- MCP tool list confirmed live: `initialize` then `tools/list` returns the 16 tools referenced here

Follow-ups in separate PRs: CI that catches this class of drift automatically (a weekly `tools/list` diff would have caught the phantom tools the day they went stale), and the README, which still carries the pricing tables and the wrong config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBQfdREiYmWs7frv4AWg5D