### PR TITLE
ci: pin the scanner action to the current commit, superseding #8

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -18,7 +18,7 @@ jobs:
       # repointed at new code, a SHA cannot.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: HOL Plugin Scanner
-        uses: hashgraph-online/ai-plugin-scanner-action@7e420247177d5beebbd3747ed16e4b29a1e41f57 # v1
+        uses: hashgraph-online/ai-plugin-scanner-action@bb4f519048c0fd1cd9d7b42056072d6070b8ad7d # v1.2.651
         with:
           plugin_dir: "."
           mode: scan


### PR DESCRIPTION
Supersedes #8.

Dependabot proposed `ai-plugin-scanner-action` v1.2.551 to v1.2.618. While applying it I checked what `v1` actually resolves to today, and the answer makes the case for pinning better than any argument does.

| | commit | bundle | date |
|---|---|---|---|
| what we had | `7e42024` | v1 | - |
| what #8 proposed | `5341f85` | v1.2.618 | 5 Sep |
| what `v1` resolves to now | `bb4f519` | v1.2.651 | 8 Sep |

**The tag moved twice in three days.** Anything tracking `@v1` silently ran three different bundles across that window. This pins to `bb4f519`, the current one.

Dependabot understands SHA pins and keeps them updated, so pinning costs nothing in maintenance. It only removes the window where a tag can be repointed at code nobody reviewed.

The same pin has been applied across the seven sibling skill bundles, so the whole family now runs one reviewed commit of this action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBQfdREiYmWs7frv4AWg5D